### PR TITLE
22 size of name and description for identity should set as in common rule

### DIFF
--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/FromModelProcessor.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/FromModelProcessor.kt
@@ -15,7 +15,7 @@ class FromModelProcessor(val codegen: CodeCodegen) {
 	fun process(codegenModel: CodegenModel): CodegenModel {
 		removeIgnoredFields(codegenModel)
 
-		applyStrategyResolver(ModelStrategyResolver(codegenModel))
+		applyStrategyResolver(ModelStrategyResolver(codegenModel, codegen))
 
 		fixEnumName(codegenModel)
 

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/models/ModelStrategyResolver.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/models/ModelStrategyResolver.kt
@@ -1,13 +1,24 @@
 package pro.bilous.codegen.process.models
 
 import com.google.common.base.CaseFormat
+import io.swagger.v3.oas.models.media.ObjectSchema
+import org.openapitools.codegen.CodeCodegen
 import org.openapitools.codegen.CodegenModel
+import org.openapitools.codegen.CodegenProperty
+import org.slf4j.LoggerFactory
+import pro.bilous.codegen.configurator.Database
+import pro.bilous.codegen.process.FromPropertyProcessor
+import pro.bilous.codegen.process.strateges.DefaultTypeResolvingStrategy
+import pro.bilous.codegen.process.strateges.MySqlTypeResolvingStrategy
+import pro.bilous.codegen.process.strateges.PostgreSqlTypeResolvingStrategy
 import pro.bilous.codegen.utils.SqlNamingUtils
 import pro.bilous.codegen.utils.SuperclassRegistry
 
-class ModelStrategyResolver(val model: CodegenModel) : IModelStrategyResolver {
+class ModelStrategyResolver(val model: CodegenModel, val codegen: CodeCodegen) : IModelStrategyResolver {
 
 	companion object {
+		private val LOGGER = LoggerFactory.getLogger(ModelStrategyResolver::class.java)
+
 		val importsToIgnore = arrayOf(
 			"ApiModel", "ApiModelProperty", "JsonProperty", "Entity", "ResourceEntity", "Identity", "Property"
 		)
@@ -23,6 +34,7 @@ class ModelStrategyResolver(val model: CodegenModel) : IModelStrategyResolver {
 
 				model.vars = model.vars.filter { "identity" != it.name && "entity" != it.name }
 				extensions["hasTableEntity"] = true
+				resolveTypesForIdentityFieldsInResourceTable()
 			}
 			args.hasId -> {
 				model.parent = "BaseDomain()"
@@ -42,6 +54,51 @@ class ModelStrategyResolver(val model: CodegenModel) : IModelStrategyResolver {
 				model.imports.add(parentType)
 			}
 		}
+	}
+
+	private fun resolveTypesForIdentityFieldsInResourceTable() {
+		val ap = codegen.additionalProperties()
+		val defaultStringSize = ap["defaultStringSize"]?.let { it as? Int }
+		val databaseName = ap["database"]?.let { it as? Database }?.name
+
+		val identitySchema = codegen.getOpenApi()?.components?.schemas?.get("Identity")?.let { it as? ObjectSchema }
+		if(identitySchema == null) {
+			LOGGER.warn("Schema \"Identity\" is not found in OpenApi")
+			return
+		}
+
+		val nameSchema = identitySchema.properties["name"]
+		val descriptionSchema = identitySchema.properties["description"]
+		val propertyProcessor = FromPropertyProcessor(codegen)
+
+		val nameProperty = nameSchema?.let { propertyProcessor.process("name", it, codegen.fromProperty("name", it)) }
+			?: CodegenProperty().apply {
+					datatypeWithEnum = "String"
+					maxLength = null
+				}
+		val descriptionProperty = descriptionSchema?.let { propertyProcessor.process("description", it, codegen.fromProperty("description", it)) }
+			?: CodegenProperty().apply {
+					datatypeWithEnum = "String"
+					maxLength = null
+					vendorExtensions["x-usage"] = "Description"
+				}
+
+		when (databaseName) {
+			"mysql" -> {
+				MySqlTypeResolvingStrategy.resolvePropertyType(nameProperty, defaultStringSize)
+				MySqlTypeResolvingStrategy.resolvePropertyType(descriptionProperty, defaultStringSize)
+			}
+			"postgresql" -> {
+				PostgreSqlTypeResolvingStrategy.resolvePropertyType(nameProperty, defaultStringSize)
+				PostgreSqlTypeResolvingStrategy.resolvePropertyType(descriptionProperty, defaultStringSize)
+			}
+			else -> {
+				DefaultTypeResolvingStrategy().resolvePropertyType(nameProperty, defaultStringSize)
+				DefaultTypeResolvingStrategy().resolvePropertyType(descriptionProperty, defaultStringSize)
+			}
+		}
+		model.vendorExtensions["identityNameType"] = nameProperty.vendorExtensions["columnType"]
+		model.vendorExtensions["identityDescriptionType"] = descriptionProperty.vendorExtensions["columnType"]
 	}
 
 	override fun cleanupImports() {

--- a/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/resources/liquibase/migrations/changeLog.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/resources/liquibase/migrations/changeLog.mustache
@@ -27,8 +27,8 @@
 			</column>
 			{{/vendorExtensions.addEntityIdVar}}
 			{{#vendorExtensions.hasTableEntity}}
-			<column name="name" type="VARCHAR(255)"/>
-			<column name="description" type="VARCHAR(510)"/>
+			<column name="name" type="{{vendorExtensions.identityNameType}}"{{^vendorExtensions.identityNameType}}"VARCHAR(255)"{{/vendorExtensions.identityNameType}}/>
+			<column name="description" type="{{vendorExtensions.identityDescriptionType}}"{{^vendorExtensions.identityDescriptionType}}"VARCHAR(510)"{{/vendorExtensions.identityDescriptionType}}/>
 			{{/vendorExtensions.hasTableEntity}}
 			{{#allVars}}
 				{{#vendorExtensions.isExtends}}

--- a/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/resources/liquibase/migrations/changeLog.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/resources/liquibase/migrations/changeLog.mustache
@@ -27,8 +27,8 @@
 			</column>
 			{{/vendorExtensions.addEntityIdVar}}
 			{{#vendorExtensions.hasTableEntity}}
-			<column name="name" type="{{vendorExtensions.identityNameType}}"{{^vendorExtensions.identityNameType}}"VARCHAR(255)"{{/vendorExtensions.identityNameType}}/>
-			<column name="description" type="{{vendorExtensions.identityDescriptionType}}"{{^vendorExtensions.identityDescriptionType}}"VARCHAR(510)"{{/vendorExtensions.identityDescriptionType}}/>
+			<column name="name" type="{{vendorExtensions.identityNameType}}{{^vendorExtensions.identityNameType}}VARCHAR(255){{/vendorExtensions.identityNameType}}"/>
+			<column name="description" type="{{vendorExtensions.identityDescriptionType}}{{^vendorExtensions.identityDescriptionType}}VARCHAR(510){{/vendorExtensions.identityDescriptionType}}"/>
 			{{/vendorExtensions.hasTableEntity}}
 			{{#allVars}}
 				{{#vendorExtensions.isExtends}}


### PR DESCRIPTION
Updated the generation of resource table fields that are corresponded to the Identity. Th fields are set to the types: 'name' as VARCHAR(<default string size>); 'description' with type VARCHAR(4096)