### PR TITLE
29 make hibernate recognize the special dbase types

### DIFF
--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/strateges/DefaultTypeResolvingStrategy.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/strateges/DefaultTypeResolvingStrategy.kt
@@ -59,7 +59,7 @@ open class DefaultTypeResolvingStrategy {
 					if (usage != null && usage == USAGE_DESCRIPTION_NAME) {
 						resolveStringTypeWithSize(DEFAULT_SIZE_FOR_DESCRIPTION)
 					} else {
-						resolveNoSizeStringType(defaultStringSize)
+						resolveStringTypeWithSize(defaultStringSize)
 					}
 				}
 			}
@@ -67,9 +67,6 @@ open class DefaultTypeResolvingStrategy {
 		if(columnDefinition != null) property.vendorExtensions["columnDefinition"] = columnDefinition
 		property.vendorExtensions["hibernateType"] = "java.lang.String"
 	}
-
-	protected open fun resolveNoSizeStringType(defaultStringSize: Int): ColumnTypePare =
-		ColumnTypePare("VARCHAR(${defaultStringSize})", null)
 
 	protected open fun resolveStringTypeWithSize(size: Int): ColumnTypePare =
 		ColumnTypePare("VARCHAR(${size})", null)

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/strateges/DefaultTypeResolvingStrategy.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/strateges/DefaultTypeResolvingStrategy.kt
@@ -2,6 +2,8 @@ package pro.bilous.codegen.process.strateges
 
 import org.openapitools.codegen.CodegenProperty
 
+data class ColumnTypePare(val columnType:String, val columnDefinition: String?)
+
 open class DefaultTypeResolvingStrategy {
 
 	companion object {
@@ -12,7 +14,7 @@ open class DefaultTypeResolvingStrategy {
 
 	fun resolvePropertyType(property: CodegenProperty, defaultStringSize: Int?) {
 		val resolvedDefaultStringSize =
-			if(defaultStringSize != null && defaultStringSize > 0) {
+			if (defaultStringSize != null && defaultStringSize > 0) {
 				defaultStringSize
 			} else {
 				DEFAULT_STRING_SIZE
@@ -47,7 +49,7 @@ open class DefaultTypeResolvingStrategy {
 	}
 
 	private fun resolveUndefinedType(property: CodegenProperty, defaultStringSize: Int) {
-		property.vendorExtensions["columnType"] =
+		val (columnType, columnDefinition) =
 			if (property.maxLength != null && property.maxLength > 0) {
 				resolveStringTypeWithSize(property.maxLength)
 			} else {
@@ -61,12 +63,16 @@ open class DefaultTypeResolvingStrategy {
 					}
 				}
 			}
+		property.vendorExtensions["columnType"] = columnType
+		if(columnDefinition != null) property.vendorExtensions["columnDefinition"] = columnDefinition
 		property.vendorExtensions["hibernateType"] = "java.lang.String"
 	}
 
-	protected open fun resolveNoSizeStringType(defaultStringSize: Int): String = "VARCHAR(${defaultStringSize})"
+	protected open fun resolveNoSizeStringType(defaultStringSize: Int): ColumnTypePare =
+		ColumnTypePare("VARCHAR(${defaultStringSize})", null)
 
-	protected open fun resolveStringTypeWithSize(size: Int): String = "VARCHAR(${size})"
+	protected open fun resolveStringTypeWithSize(size: Int): ColumnTypePare =
+		ColumnTypePare("VARCHAR(${size})", null)
 
-	protected open fun resolveStringTypeWithFormat(format: String): String? = null
+	protected open fun resolveStringTypeWithFormat(format: String): ColumnTypePare? = null
 }

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/strateges/MySqlTypeResolvingStrategy.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/strateges/MySqlTypeResolvingStrategy.kt
@@ -2,22 +2,38 @@ package pro.bilous.codegen.process.strateges
 
 object MySqlTypeResolvingStrategy : DefaultTypeResolvingStrategy() {
 
-	private val DATA_TYPES = setOf(
-		"TINYBLOB", "TEXT", "TINYTEXT", "BLOB", "MEDIUMBLOB", "MEDIUMTEXT", "LONGBLOB", "LONGTEXT"
+	private val DATA_TYPES = mapOf(
+		"TINYBLOB" to "tinyblob",
+		"TEXT" to "text",
+		"TINYTEXT" to "tinytext",
+		"BLOB" to "blob",
+		"MEDIUMBLOB" to "mediumblob",
+		"MEDIUMTEXT" to "mediumtext",
+		"LONGBLOB" to "longblob",
+		"LONGTEXT" to "longtext"
 	)
 
 	private const val MAX_SIZE_FOR_VARCHAR = 21844
 
-	override fun resolveNoSizeStringType(defaultStringSize: Int): String {
+	override fun resolveNoSizeStringType(defaultStringSize: Int): ColumnTypePare {
 		return resolveStringTypeWithSize(defaultStringSize)
 	}
 
-	override fun resolveStringTypeWithSize(size: Int): String {
-		return if (size <= MAX_SIZE_FOR_VARCHAR) "VARCHAR(${size})" else "TEXT"
+	override fun resolveStringTypeWithSize(size: Int): ColumnTypePare {
+		return if (size <= MAX_SIZE_FOR_VARCHAR) {
+			ColumnTypePare("VARCHAR(${size})", null)
+		} else {
+			ColumnTypePare("TEXT", DATA_TYPES["TEXT"])
+		}
 	}
 
-	override fun resolveStringTypeWithFormat(format: String): String? {
-		val type = format.trim().toUpperCase()
-		return if (DATA_TYPES.contains(type)) type else null
+	override fun resolveStringTypeWithFormat(format: String): ColumnTypePare? {
+		val columnType = format.trim().toUpperCase()
+		val columnDefinition = DATA_TYPES[columnType]
+		return if (columnDefinition != null) {
+			ColumnTypePare(columnType, columnDefinition)
+		} else {
+			null
+		}
 	}
 }

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/strateges/MySqlTypeResolvingStrategy.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/strateges/MySqlTypeResolvingStrategy.kt
@@ -15,10 +15,6 @@ object MySqlTypeResolvingStrategy : DefaultTypeResolvingStrategy() {
 
 	private const val MAX_SIZE_FOR_VARCHAR = 21844
 
-	override fun resolveNoSizeStringType(defaultStringSize: Int): ColumnTypePare {
-		return resolveStringTypeWithSize(defaultStringSize)
-	}
-
 	override fun resolveStringTypeWithSize(size: Int): ColumnTypePare {
 		return if (size <= MAX_SIZE_FOR_VARCHAR) {
 			ColumnTypePare("VARCHAR(${size})", null)

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/strateges/PostgreSqlTypeResolvingStrategy.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/strateges/PostgreSqlTypeResolvingStrategy.kt
@@ -9,10 +9,6 @@ object PostgreSqlTypeResolvingStrategy : DefaultTypeResolvingStrategy() {
 
 	private const val MAX_SIZE_FOR_VARCHAR = 10485760
 
-	override fun resolveNoSizeStringType(defaultStringSize: Int): ColumnTypePare {
-		return ColumnTypePare("VARCHAR", DATA_TYPES["VARCHAR"])
-	}
-
 	override fun resolveStringTypeWithSize(size: Int): ColumnTypePare {
 		return if (size <= MAX_SIZE_FOR_VARCHAR) {
 			ColumnTypePare("VARCHAR(${size})", null)

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/strateges/PostgreSqlTypeResolvingStrategy.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/strateges/PostgreSqlTypeResolvingStrategy.kt
@@ -2,20 +2,32 @@ package pro.bilous.codegen.process.strateges
 
 object PostgreSqlTypeResolvingStrategy : DefaultTypeResolvingStrategy() {
 
-	private val DATA_TYPES = setOf("VARCHAR", "TEXT")
+	private val DATA_TYPES = mapOf(
+		"VARCHAR" to "varchar",
+		"TEXT" to "text",
+	)
 
 	private const val MAX_SIZE_FOR_VARCHAR = 10485760
 
-	override fun resolveNoSizeStringType(defaultStringSize: Int): String {
-		return "VARCHAR"
+	override fun resolveNoSizeStringType(defaultStringSize: Int): ColumnTypePare {
+		return ColumnTypePare("VARCHAR", DATA_TYPES["VARCHAR"])
 	}
 
-	override fun resolveStringTypeWithSize(size: Int): String {
-		return if (size <= MAX_SIZE_FOR_VARCHAR) "VARCHAR(${size})" else "TEXT"
+	override fun resolveStringTypeWithSize(size: Int): ColumnTypePare {
+		return if (size <= MAX_SIZE_FOR_VARCHAR) {
+			ColumnTypePare("VARCHAR(${size})", null)
+		} else {
+			ColumnTypePare("TEXT", DATA_TYPES["TEXT"])
+		}
 	}
 
-	override fun resolveStringTypeWithFormat(format: String): String? {
-		val type = format.trim().toUpperCase()
-		return if (DATA_TYPES.contains(type)) type else null
+	override fun resolveStringTypeWithFormat(format: String): ColumnTypePare? {
+		val columnType = format.trim().toUpperCase()
+		val columnDefinition = DATA_TYPES[columnType]
+		return if (columnDefinition != null) {
+			ColumnTypePare(columnType, columnDefinition)
+		} else {
+			null
+		}
 	}
 }

--- a/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/kotlin/domain/columnDefinition.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/kotlin/domain/columnDefinition.mustache
@@ -1,0 +1,1 @@
+{{#vendorExtensions.columnDefinition}}, columnDefinition = "{{vendorExtensions.columnDefinition}}"{{/vendorExtensions.columnDefinition}}

--- a/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/kotlin/domain/pojoentity.kt.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/kotlin/domain/pojoentity.kt.mustache
@@ -87,7 +87,7 @@ data class {{classname}}(
 	@JoinColumn(name = "{{{vendorExtensions.escapedColumnName}}}", referencedColumnName = "id")
 	{{/vendorExtensions.isOneToOne}}
 	{{^vendorExtensions.isOneToOne}}
-	@Column(name = "{{{vendorExtensions.escapedColumnName}}}")
+	@Column(name = "{{{vendorExtensions.escapedColumnName}}}"{{>app-module/src/main/kotlin/domain/columnDefinition}})
 	{{/vendorExtensions.isOneToOne}}
 	{{/isListContainer}}
 	{{/vendorExtensions.hasJsonType}}

--- a/codegen-cli/src/test/java/pro/bilous/codegen/process/strateges/PostgreSqlTypeResolvingStrategyTest.kt
+++ b/codegen-cli/src/test/java/pro/bilous/codegen/process/strateges/PostgreSqlTypeResolvingStrategyTest.kt
@@ -40,7 +40,7 @@ class PostgreSqlTypeResolvingStrategyTest {
 
 	@Test
 	@DisplayName(
-		"Should assign type VARCHAR if property datatype is undefined" +
+		"Should assign type VARCHAR(DEFAULT_STRING_SIZE) if property datatype is undefined" +
 				"and property.maxLength is undefined"
 	)
 	fun `should assign VARCHAR with default string size`() {
@@ -49,7 +49,7 @@ class PostgreSqlTypeResolvingStrategyTest {
 		PostgreSqlTypeResolvingStrategy.resolvePropertyType(property, DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("VARCHAR", ve["columnType"])
+		kotlin.test.assertEquals("VARCHAR(${DEFAULT_STRING_SIZE})", ve["columnType"])
 		kotlin.test.assertEquals("java.lang.String", ve["hibernateType"])
 	}
 


### PR DESCRIPTION
Hibernate can't recognize the base specific types (TEXT, BLOB, TINYTEXT ets). Should update generator to add type specific param for the column definition in entity class