### PR TITLE
#70 fixed invalid dot replacement in project folder name

### DIFF
--- a/codegen-cli/src/test/java/org/openapitools/codegen/CodeCodegenTest.kt
+++ b/codegen-cli/src/test/java/org/openapitools/codegen/CodeCodegenTest.kt
@@ -40,4 +40,59 @@ internal class CodeCodegenTest {
 		val gen = CodeCodegen()
 		gen.postProcess()
 	}
+
+	@Test
+	fun `should return full path of the generated service`() {
+		val template = "template/service.mustache"
+		val gen = TestCodegen(template)
+		val expected = "my.projects/project/app-service/src/main/kotlin/my/package/com/service/file.kt".fixSeparator()
+		assertEquals(expected, gen.apiFilename(template, "file"))
+	}
+
+	@Test
+	fun `should return full path of the generated repository`() {
+		val template = "template/repository.mustache"
+		val gen = TestCodegen(template)
+		val expected = "my.projects/project/app-service/src/main/kotlin/my/package/com/repository/file.kt".fixSeparator()
+		assertEquals(expected, gen.apiFilename(template, "file"))
+	}
+
+	@Test
+	fun `should return full path of the generated api controller`() {
+		val template = "template/api.mustache"
+		val gen = TestCodegen(template)
+		val expected = "my.projects/project/app-service/src/main/kotlin/my/package/com/controller/api/file.kt".fixSeparator()
+		assertEquals(expected, gen.apiFilename(template, "file"))
+	}
+
+	@Test
+	fun `should return full path of the generated controller`() {
+		val template = "template/apiController.mustache"
+		val gen = TestCodegen(template)
+		val expected = "my.projects/project/app-service/src/main/kotlin/my/package/com/controller/file.kt".fixSeparator()
+		assertEquals(expected, gen.apiFilename(template, "file"))
+	}
+
+	@Test
+	fun `should return full path of the common generated file`() {
+		val template = "template/any.mustache"
+		val gen = TestCodegen(template)
+		val expected = "my.projects/project/app-service/src/main/kotlin/repository-package/api-file.kt".fixSeparator()
+		assertEquals(expected, gen.apiFilename(template, "file"))
+	}
+
+	class TestCodegen(template: String) : CodeCodegen() {
+		init {
+			additionalProperties["appPackage"] = "my.package.com"
+			outputFolder = "my.projects/project"
+			artifactId = "service"
+			apiTemplateFiles[template] = ".kt"
+			entityMode = true
+			repositoryPackage = "repository-package"
+		}
+
+		override fun toApiFilename(name: String?) = "api-file"
+	}
+
+	private fun String.fixSeparator() = this.replace('/', File.separatorChar)
 }


### PR DESCRIPTION
Sample:
project folder name "C:\Users\Me.User\my-project"
will be transformed to "C:\Users\Me\User\my-project"
which will invoke Error while api is generated