### PR TITLE
added 'limit' to the list of SQL names that must be escaped

### DIFF
--- a/codegen-cli/src/main/java/pro/bilous/codegen/utils/SqlNamingUtils.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/utils/SqlNamingUtils.kt
@@ -17,7 +17,8 @@ object SqlNamingUtils {
 		"order",
 		"procedure",
 		"from",
-		"condition"
+		"condition",
+		"limit"
 	)
 
 	private val columnNamesToEscape = sqlNamesToEscape


### PR DESCRIPTION
added 'limit' t the list of SQL names that must be escaped and suffixed by '_'