### PR TITLE
removed 'Translation' from the defaultMapping map

### DIFF
--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsImportMappings.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsImportMappings.kt
@@ -14,7 +14,7 @@ class OptsImportMappings(val codegen: CodeCodegen) {
 //			"History" to "$basePackage.domain.History",
 //			"DomainResource" to "DomainResource",
 //			"BindingType" to "BindingType",
-//			"Translation" to "Translation",
+			"Translation" to "Translation",
 			"Error" to "Error",
 			"Entity_1" to "Entity",
 			"Error_1" to "Error",

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsImportMappings.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsImportMappings.kt
@@ -14,7 +14,7 @@ class OptsImportMappings(val codegen: CodeCodegen) {
 //			"History" to "$basePackage.domain.History",
 //			"DomainResource" to "DomainResource",
 //			"BindingType" to "BindingType",
-			"Translation" to "Translation",
+//			"Translation" to "Translation",
 			"Error" to "Error",
 			"Entity_1" to "Entity",
 			"Error_1" to "Error",

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsPostProcessor.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsPostProcessor.kt
@@ -85,6 +85,7 @@ class OptsPostProcessor(val codegen: CodeCodegen) {
 
 		typeMapping["file"] = "Resource"
 		OptsImportMappings(codegen).addDefaultMappings()
+		resolveDefaultMappings()
 
 		val appRoot = "app-${artifactId.toLowerCase()}"
 
@@ -335,6 +336,13 @@ class OptsPostProcessor(val codegen: CodeCodegen) {
 	private fun isOpentelemetry(): Boolean {
 		val it = additionalProperties["opentelemetry"] as? Map<*, *> ?: return false
 		return it["enabled"] as? Boolean ?: false
+	}
+
+	private fun resolveDefaultMappings() {
+		val importMapping = codegen.importMapping()
+		val generationProperty = additionalProperties["generation"] as? Map<String, Any> ?: return
+		val excludedFromDefaultMapping = generationProperty["excludeFromDefaultMapping"] as? List<String> ?: return
+		importMapping.keys.removeAll(excludedFromDefaultMapping.toSet())
 	}
 
 }

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsPostProcessor.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsPostProcessor.kt
@@ -85,7 +85,7 @@ class OptsPostProcessor(val codegen: CodeCodegen) {
 
 		typeMapping["file"] = "Resource"
 		OptsImportMappings(codegen).addDefaultMappings()
-		resolveDefaultMappings()
+		resolveMappings()
 
 		val appRoot = "app-${artifactId.toLowerCase()}"
 
@@ -338,11 +338,11 @@ class OptsPostProcessor(val codegen: CodeCodegen) {
 		return it["enabled"] as? Boolean ?: false
 	}
 
-	private fun resolveDefaultMappings() {
+	private fun resolveMappings() {
 		val importMapping = codegen.importMapping()
 		val generationProperty = additionalProperties["generation"] as? Map<String, Any> ?: return
-		val excludedFromDefaultMapping = generationProperty["excludeFromDefaultMapping"] as? List<String> ?: return
-		importMapping.keys.removeAll(excludedFromDefaultMapping.toSet())
+		val excludedFromMapping = generationProperty["excludeFromMapping"] as? List<String> ?: return
+		importMapping.keys.removeAll(excludedFromMapping.toSet())
 	}
 
 }

--- a/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/domain/commonPojoentity.kt.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/domain/commonPojoentity.kt.mustache
@@ -100,7 +100,7 @@
 	@Column(name = "id", insertable = false, updatable = false)
 	{{/vendorExtensions.readOnlyColumn}}
 	{{^vendorExtensions.readOnlyColumn}}
-	@Column(name = "{{{vendorExtensions.escapedColumnName}}}")
+	@Column(name = "{{{vendorExtensions.escapedColumnName}}}"{{>app-module/src/main/kotlin/domain/columnDefinition}})
 	{{/vendorExtensions.readOnlyColumn}}
 	{{/vendorExtensions.isOneToOne}}
     {{/isArray}}

--- a/codegen-cli/src/test/java/pro/bilous/codegen/process/OptsPostProcessorTest.kt
+++ b/codegen-cli/src/test/java/pro/bilous/codegen/process/OptsPostProcessorTest.kt
@@ -63,5 +63,19 @@ internal class OptsPostProcessorTest {
 		additionalProperties()["appRealName"] = "test"
 	}
 
+	@Test
+	fun `check if mapping resolved`() {
+		val exclusion = "Test"
+		val codegen = mockCodegen().apply {
+			additionalProperties()["generation"] = mapOf(
+				"excludeFromMapping" to listOf(exclusion)
+			)
+			getImportMappings()[exclusion] = exclusion
+		}
+		val processor = OptsPostProcessor(codegen)
+		processor.processOpts()
+		assertFalse(codegen.getImportMappings().contains(exclusion))
+	}
+
 }
 


### PR DESCRIPTION
Removed 'Translation' from the defaultMapping map. This made 'Translation' a common entity that will be generated as others