### PR TITLE
fixed assertion of null parentId from path with entity.parent.id

### DIFF
--- a/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/controller/ControllerDelegate.kt.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/controller/ControllerDelegate.kt.mustache
@@ -32,7 +32,9 @@ class ControllerDelegate<E: BaseResource, S: CommonService<E>>(val  service: S) 
 	fun getById(id: String, parentId: String? = null, preGet: (E) -> Unit = {}): ResponseEntity<E> {
 		val result = service.getById(id) ?: throw ResourceNotFoundException()
 		{{#hasEntityBlocks}}
-		Assert.isTrue(parentId == result.entity.parent?.id, "parent $parentId is not valid")
+		if (parentId != null) {
+			Assert.isTrue(parentId == result.entity.parent?.id, "Path parent '$parentId' is not valid")
+		}
 		{{/hasEntityBlocks}}
 		{{^hasEntityBlocks}}
 		//TODO: should assert parent id here


### PR DESCRIPTION
When endpoint misses 'parentId' the parameter 'parentId' in getById() is null by default. So, we must not compare this 'null' parentId with entity.parent.id