### PR TITLE
add v2 to securityGuard

### DIFF
--- a/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/config/guards/RequestReferenceGuard.kt.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/config/guards/RequestReferenceGuard.kt.mustache
@@ -1,5 +1,9 @@
 package {{basePackage}}.config.guards
 
+{{#security.guards.referenceGuard.v2}}
+import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken
+import org.springframework.security.core.Authentication
+{{/security.guards.referenceGuard.v2}}
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
@@ -14,8 +18,47 @@ class RequestReferenceGuard(private val rest: RestTemplate) {
 
 	companion object {
 		private val log = LoggerFactory.getLogger(RequestHeaderGuard::class.java)
+{{#security.guards.referenceGuard.v2}}
+		private const val REQUIRED_CLAIM = "parties"
+		private const val ACCESS_HEADER_NAME = "X-access-partyId"
+		private const val RESOURCE_URI_HEADER_NAME = "X-resource-URI"
+		private const val RESOURCE_METHOD_HEADER_NAME = "X-resource-method"
+{{/security.guards.referenceGuard.v2}}
 	}
 
+{{#security.guards.referenceGuard.v2}}
+	fun check(auth: Authentication,
+			  request: HttpServletRequest,
+			  headerName: String,
+			  format: String): Boolean {
+		if (auth !is KeycloakAuthenticationToken) {
+			log.warn("Authentication has unsupported type")
+			return false
+		}
+		val header = request.getHeader(headerName)
+		if (header == null) {
+			log.debug("Header $headerName is missing")
+			return false
+		}
+		val accessHeader = request.getHeader(ACCESS_HEADER_NAME)
+		if (accessHeader == null) {
+			log.debug("Access header '$ACCESS_HEADER_NAME' is missing")
+			return false
+		}
+		val claims = auth.account.keycloakSecurityContext.token.otherClaims
+		if (claims.isNullOrEmpty()) {
+			log.warn("Claims not found in token")
+			return false
+		}
+		val claimsList = (claims[REQUIRED_CLAIM] ?: {
+			log.warn("Claim '$REQUIRED_CLAIM' not found in token")
+			false
+		}).toString().split(",")
+		if(!claimsList.contains(accessHeader)) {
+			return false
+		}
+{{/security.guards.referenceGuard.v2}}
+{{^security.guards.referenceGuard.v2}}
 	fun check(request: HttpServletRequest,
 			  headerName: String,
 			  format: String): Boolean {
@@ -24,6 +67,7 @@ class RequestReferenceGuard(private val rest: RestTemplate) {
 			log.debug("Header $headerName is missing")
 			return false
 		}
+{{/security.guards.referenceGuard.v2}}
 
 		val formatParts = format.split("/")
 		// 1st part should define host of the application
@@ -41,7 +85,13 @@ class RequestReferenceGuard(private val rest: RestTemplate) {
 			for (itHeader in request.headerNames) {
 				set(itHeader, request.getHeader(itHeader))
 			}
+{{#security.guards.referenceGuard.v2}}
+			set(RESOURCE_URI_HEADER_NAME, request.requestURI)
+			set(RESOURCE_METHOD_HEADER_NAME, request.method)
+{{/security.guards.referenceGuard.v2}}
+{{^security.guards.referenceGuard.v2}}
 			set("X-entity-partyId", request.getHeader("X-access-partyId"))
+{{/security.guards.referenceGuard.v2}}
 		})
 
 		return try {

--- a/codegen-cli/src/test/java/pro/bilous/codegen/process/OpenApiProcessorTest.kt
+++ b/codegen-cli/src/test/java/pro/bilous/codegen/process/OpenApiProcessorTest.kt
@@ -1,0 +1,68 @@
+package pro.bilous.codegen.process
+
+import io.swagger.models.parameters.HeaderParameter
+import org.junit.jupiter.api.Test
+
+import org.junit.Assert.*
+import org.openapitools.codegen.CodeCodegen
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.PathItem
+import io.swagger.v3.oas.models.Paths
+import io.swagger.v3.oas.models.parameters.Parameter
+
+class OpenApiProcessorTest {
+
+    @Test
+    fun `createAuthRules for Secured Path with ReferenceGuardV2`() {
+		val codegen = CodeCodegen().apply {
+			val additionalProperties = additionalProperties()
+			additionalProperties["security"] = mapOf(
+				"guards" to mapOf(
+					"referenceGuard" to mapOf(
+						"v2" to true
+					)
+				)
+			)
+		}
+		val processor = OpenApiProcessor(codegen)
+		val openApi = OpenAPI().apply {
+			paths = Paths().apply {
+				set("/root", PathItem().apply {
+					get = Operation().apply {
+						parameters = listOf<Parameter>(
+							Parameter().apply {
+								`in` = "header"
+								name = "X-access-reference"
+								extensions = mapOf(
+									"x-auth-format" to "test-auth-format",
+									"x-auth-access" to "test-auth-access"
+								)
+							},
+							Parameter().apply {
+								`in` = "header"
+								name = "bearer"
+							}
+						)
+					}
+				})
+			}
+		}
+		val guardsSet = mutableSetOf<Map<String, Any?>>()
+		val result = processor.createAuthRules(openApi, guardsSet)
+		val expected = setOf(mapOf(
+			"antMatcher" to "/root",
+			"secured" to true,
+			"guards" to listOf(mapOf(
+				"headerName" to "X-access-reference",
+				"guardName" to "referenceGuard",
+				"guardClassName" to "ReferenceGuard",
+				"format" to "test-auth-format",
+				"args" to listOf("authentication", "request", "'X-access-reference'", "'test-auth-format'")
+			)),
+			"multiGuards" to false,
+			"hasGuards" to true
+		))
+		assertEquals(expected, result)
+    }
+}


### PR DESCRIPTION
Need to pass URI, X-entity-psrtyId to enforser for ability to math scopes. And only authenticated file is allowed.
In settings.yml the next parameters must be added:
```
security:
  guards:
    referenceGuard:
      v2: true
```
The generated guard:

```
@referenceGuard.check(authentication, request, 'X-access-reference', 'client-folder/{referenceUri}/enforce')

@Component("referenceGuard")
class RequestReferenceGuard(private val rest: RestTemplate) {

	companion object {
		private val log = LoggerFactory.getLogger(RequestHeaderGuard::class.java)
		private const val REQUIRED_CLAIM = "parties"
		private const val ACCESS_HEADER_NAME = "X-access-partyId"
		private const val RESOURCE_URI_HEADER_NAME = "X-resource-URI"
		private const val RESOURCE_METHOD_HEADER_NAME = "X-resource-method"
	}

	fun check(auth: Authentication,
			  request: HttpServletRequest,
			  headerName: String,
			  format: String): Boolean {
		if (auth !is KeycloakAuthenticationToken) {
			log.warn("Authentication has unsupported type")
			return false
		}
		val header = request.getHeader(headerName)
		if (header == null) {
			log.debug("Header $headerName is missing")
			return false
		}
		val accessHeader = request.getHeader(ACCESS_HEADER_NAME)
		if (accessHeader == null) {
			log.debug("Access header '$ACCESS_HEADER_NAME' is missing")
			return false
		}
		val claims = auth.account.keycloakSecurityContext.token.otherClaims
		if (claims.isNullOrEmpty()) {
			log.warn("Claims not found in token")
			return false
		}
		val claimsList = (claims[REQUIRED_CLAIM] ?: {
			log.warn("Claim '$REQUIRED_CLAIM' not found in token")
			false
		}).toString().split(",")
		if(!claimsList.contains(accessHeader)) {
			return false
		}

		val formatParts = format.split("/")
		// 1st part should define host of the application
		// 2nd part is variable {referenceUri} to replace or uri
		// 3rd is optional suffix
		if (formatParts.size < 2) {
			log.error("Can not build uri from invalid format")
			return false
		}
		val host = "${formatParts[0]}:8080"
		val resource = formatParts.drop(1).joinToString("/").replace("{referenceUri}", header)
		val uri = "http://$host/$resource"

		val exchangeRequest = HttpEntity<String>(HttpHeaders().apply {
			for (itHeader in request.headerNames) {
				set(itHeader, request.getHeader(itHeader))
			}
			set(RESOURCE_URI_HEADER_NAME, request.requestURI)
			set(RESOURCE_METHOD_HEADER_NAME, request.method)
		})

		return try {
			rest.exchange(uri, HttpMethod.POST, exchangeRequest, Boolean::class.java).body ?: false
		} catch (e: Exception) {
			log.error("Failed while request enforcer $uri", e)
			return false
		}
	}
}
```
