### PR TITLE
added resolving property format 'VERSION'

### DIFF
--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/strategy/DefaultTypeResolvingStrategy.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/strategy/DefaultTypeResolvingStrategy.kt
@@ -9,6 +9,7 @@ open class DefaultTypeResolvingStrategy {
 	companion object {
 		const val DEFAULT_STRING_SIZE = 255
 		const val USAGE_DESCRIPTION_NAME = "Description"
+		const val FORMAT_VERSION = "VERSION"
 		const val DEFAULT_SIZE_FOR_DESCRIPTION = 4096
 	}
 
@@ -53,6 +54,8 @@ open class DefaultTypeResolvingStrategy {
 				resolveUndefinedType(property, resolvedDefaultStringSize)
 			}
 		}
+
+		resolveFormatVersion(property)
 	}
 
 	private fun resolveUndefinedType(property: CodegenProperty, defaultStringSize: Int) {
@@ -79,4 +82,11 @@ open class DefaultTypeResolvingStrategy {
 		ColumnTypePare("VARCHAR(${size})", null)
 
 	protected open fun resolveStringTypeWithFormat(format: String): ColumnTypePare? = null
+
+	private fun resolveFormatVersion(property: CodegenProperty) {
+		val format = property.vendorExtensions["x-format"]?.let { it as? String } ?: return
+		if (format.equals(FORMAT_VERSION, ignoreCase = true)) {
+			property.vendorExtensions["formatVersion"] = true
+		}
+	}
 }

--- a/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/kotlin/domain/pojoentity.kt.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/kotlin/domain/pojoentity.kt.mustache
@@ -102,6 +102,9 @@
 	@JoinColumn(name = "{{{vendorExtensions.escapedColumnName}}}", referencedColumnName = "id")
 	{{/vendorExtensions.isOneToOne}}
 	{{^vendorExtensions.isOneToOne}}
+	{{#vendorExtensions.formatVersion}}
+	@Version
+	{{/vendorExtensions.formatVersion}}
 	@Column(name = "{{{vendorExtensions.escapedColumnName}}}"{{>app-module/src/main/kotlin/domain/columnDefinition}})
 	{{/vendorExtensions.isOneToOne}}
 	{{/isArray}}

--- a/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/domain/commonPojoentity.kt.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/domain/commonPojoentity.kt.mustache
@@ -100,6 +100,9 @@
 	@Column(name = "id", insertable = false, updatable = false)
 	{{/vendorExtensions.readOnlyColumn}}
 	{{^vendorExtensions.readOnlyColumn}}
+	{{#vendorExtensions.formatVersion}}
+	@Version
+	{{/vendorExtensions.formatVersion}}
 	@Column(name = "{{{vendorExtensions.escapedColumnName}}}"{{>app-module/src/main/kotlin/domain/columnDefinition}})
 	{{/vendorExtensions.readOnlyColumn}}
 	{{/vendorExtensions.isOneToOne}}

--- a/codegen-cli/src/test/java/pro/bilous/codegen/process/strategy/DefaultTypeResolvingStrategyTest.kt
+++ b/codegen-cli/src/test/java/pro/bilous/codegen/process/strategy/DefaultTypeResolvingStrategyTest.kt
@@ -25,8 +25,8 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, PROJECT_DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("\${BOOLEAN_VALUE}", ve["columnType"])
-		kotlin.test.assertEquals("java.lang.Boolean", ve["hibernateType"])
+		assertEquals("\${BOOLEAN_VALUE}", ve["columnType"])
+		assertEquals("java.lang.Boolean", ve["hibernateType"])
 		kotlin.test.assertTrue(property.isBoolean)
 	}
 
@@ -40,8 +40,8 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, PROJECT_DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("\${BOOLEAN_VALUE}", ve["columnType"])
-		kotlin.test.assertEquals("java.lang.Boolean", ve["hibernateType"])
+		assertEquals("\${BOOLEAN_VALUE}", ve["columnType"])
+		assertEquals("java.lang.Boolean", ve["hibernateType"])
 		kotlin.test.assertTrue(property.isBoolean)
 	}
 
@@ -55,8 +55,8 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, PROJECT_DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("datetime", ve["columnType"])
-		kotlin.test.assertEquals("java.util.Date", ve["hibernateType"])
+		assertEquals("datetime", ve["columnType"])
+		assertEquals("java.util.Date", ve["hibernateType"])
 		kotlin.test.assertTrue(property.isDate)
 	}
 
@@ -70,8 +70,8 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, PROJECT_DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("datetime", ve["columnType"])
-		kotlin.test.assertEquals("java.util.Date", ve["hibernateType"])
+		assertEquals("datetime", ve["columnType"])
+		assertEquals("java.util.Date", ve["hibernateType"])
 		kotlin.test.assertTrue(property.isDate)
 	}
 
@@ -85,7 +85,7 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, PROJECT_DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("int", ve["columnType"])
+		assertEquals("int", ve["columnType"])
 		kotlin.test.assertTrue(property.isInteger)
 	}
 
@@ -99,7 +99,7 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, PROJECT_DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("int", ve["columnType"])
+		assertEquals("int", ve["columnType"])
 		kotlin.test.assertTrue(property.isInteger)
 	}
 
@@ -113,7 +113,7 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, PROJECT_DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("decimal(10,2)", ve["columnType"])
+		assertEquals("decimal(10,2)", ve["columnType"])
 		kotlin.test.assertTrue(property.isNumber)
 	}
 
@@ -127,7 +127,7 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, PROJECT_DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("decimal(10,2)", ve["columnType"])
+		assertEquals("decimal(10,2)", ve["columnType"])
 		kotlin.test.assertTrue(property.isNumber)
 	}
 
@@ -141,7 +141,7 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, PROJECT_DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("bigint", ve["columnType"])
+		assertEquals("bigint", ve["columnType"])
 		kotlin.test.assertTrue(property.isNumber)
 	}
 
@@ -155,7 +155,7 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, PROJECT_DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("bigint", ve["columnType"])
+		assertEquals("bigint", ve["columnType"])
 		kotlin.test.assertTrue(property.isNumber)
 	}
 
@@ -170,8 +170,8 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, PROJECT_DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("VARCHAR(${PROPERTY_MAX_LENGTH})", ve["columnType"])
-		kotlin.test.assertEquals("java.lang.String", ve["hibernateType"])
+		assertEquals("VARCHAR(${PROPERTY_MAX_LENGTH})", ve["columnType"])
+		assertEquals("java.lang.String", ve["hibernateType"])
 	}
 
 	@Test
@@ -184,8 +184,8 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, PROJECT_DEFAULT_STRING_SIZE)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("VARCHAR(${PROJECT_DEFAULT_STRING_SIZE})", ve["columnType"])
-		kotlin.test.assertEquals("java.lang.String", ve["hibernateType"])
+		assertEquals("VARCHAR(${PROJECT_DEFAULT_STRING_SIZE})", ve["columnType"])
+		assertEquals("java.lang.String", ve["hibernateType"])
 	}
 
 	@Test
@@ -202,8 +202,8 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, null)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("VARCHAR(${STRING_SIZE_WHEN_USAGE_IS_DESCRIPTION})", ve["columnType"])
-		kotlin.test.assertEquals("java.lang.String", ve["hibernateType"])
+		assertEquals("VARCHAR(${STRING_SIZE_WHEN_USAGE_IS_DESCRIPTION})", ve["columnType"])
+		assertEquals("java.lang.String", ve["hibernateType"])
 	}
 
 	@Test
@@ -217,8 +217,8 @@ class DefaultTypeResolvingStrategyTest {
 		resolvingStrategy.resolvePropertyType(property, null)
 
 		val ve = property.vendorExtensions
-		kotlin.test.assertEquals("VARCHAR(${DEFAULT_STRING_SIZE})", ve["columnType"])
-		kotlin.test.assertEquals("java.lang.String", ve["hibernateType"])
+		assertEquals("VARCHAR(${DEFAULT_STRING_SIZE})", ve["columnType"])
+		assertEquals("java.lang.String", ve["hibernateType"])
 	}
 
 	@Test
@@ -233,5 +233,16 @@ class DefaultTypeResolvingStrategyTest {
 		assertEquals("\${TEXT_TYPE}", property.vendorExtensions["columnType"])
 		assertEquals("java.lang.String", property.vendorExtensions["hibernateType"])
 		assertEquals("text", property.vendorExtensions["columnDefinition"])
+	}
+
+	@Test
+	@DisplayName("Should set vendorExtension.formatVersion TRUE if property.format == VERSION")
+	fun `should add formatVersion to true for property with format VERSION`() {
+		val property = CodegenProperty().apply {
+			datatypeWithEnum = "Integer"
+			vendorExtensions["x-format"] = "VERSION"
+		}
+		DefaultTypeResolvingStrategy().resolvePropertyType(property)
+		assertEquals(true, property.vendorExtensions["formatVersion"] as? Boolean)
 	}
 }


### PR DESCRIPTION
To add the annotation @Version to some field it's only necessary to set the format of this field to 'VERSION'. It works for simple (not embedded or mapped fields) only