### PR TITLE
102 add custom prefix to modules

### DIFF
--- a/codegen-cli/src/main/java/org/openapitools/codegen/CodeCodegen.kt
+++ b/codegen-cli/src/main/java/org/openapitools/codegen/CodeCodegen.kt
@@ -34,11 +34,20 @@ open class CodeCodegen : AbstractJavaCodegen() {
 		const val OPENAPI_DOCKET_CONFIG = "swaggerDocketConfig"
 		const val DB_NAME = "dbName"
 		const val BINDING_KEY = "addBindingEntity"
+		const val DEFAULT_MODULE_PREFIX_NAME = "app-"
+
+		fun resolveModulePrefixName(properties: Map<String, Any>): String {
+			val generationProperty = properties["generation"] as? Map<String, Any>
+				?: return DEFAULT_MODULE_PREFIX_NAME
+			return generationProperty["modulePrefixName"] as? String ?: DEFAULT_MODULE_PREFIX_NAME
+		}
 	}
 
 	fun isEnableMerge(): Boolean {
 		return additionalProperties.containsKey("enableMerge") && additionalProperties["enableMerge"] as Boolean
 	}
+
+	val modulePrefixName: String by lazy { resolveModulePrefixName(additionalProperties) }
 
 	fun getOpenApi() = openAPI
 
@@ -306,7 +315,7 @@ open class CodeCodegen : AbstractJavaCodegen() {
 	override fun apiFilename(templateName: String, tag: String): String {
 		val suffix = apiTemplateFiles()[templateName]
 
-		val outSrc = "$outputFolder/app-$artifactId/src/main/kotlin"
+		val outSrc = "$outputFolder/$modulePrefixName$artifactId/src/main/kotlin"
 
 		val appPackageName = additionalProperties["appPackage"] as? String
 			?: throw IllegalArgumentException("invalid package name - it should be a string")
@@ -377,12 +386,12 @@ open class CodeCodegen : AbstractJavaCodegen() {
 	}
 
 	private fun getFolder(sourcePackage: String?, subModule: String): String {
-		val subFolder = "app-$artifactId"
+		val subFolder = "$modulePrefixName$artifactId"
 		return (subFolder + File.separator + "src/main/kotlin" + File.separator + sourcePackage).fixDot().fixSeparator()
 	}
 
 	fun getTestFolder(sourcePackage: String?, subModule: String): String {
-		val subFolder = "app-$artifactId"
+		val subFolder = "$modulePrefixName$artifactId"
 		val rightSourcePkg = sourcePackage?.replace("repository", "controller")
 		return (subFolder + File.separator + "src/test/kotlin" + File.separator + rightSourcePkg).fixDot().fixSeparator()
 	}

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsPostProcessor.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsPostProcessor.kt
@@ -26,6 +26,9 @@ class OptsPostProcessor(val codegen: CodeCodegen) {
 
 	private val artifactId = codegen.artifactId
 
+	private val modulePrefixName: String
+		get() = codegen.modulePrefixName
+
 	private val basePackage: String
 		get() = codegen.basePackage
 
@@ -87,7 +90,7 @@ class OptsPostProcessor(val codegen: CodeCodegen) {
 		OptsImportMappings(codegen).addDefaultMappings()
 		resolveMappings()
 
-		val appRoot = "app-${artifactId.toLowerCase()}"
+		val appRoot = "$modulePrefixName${artifactId.toLowerCase()}"
 
 		if (mainIndex) {
 			setupRootFiles()
@@ -156,7 +159,7 @@ class OptsPostProcessor(val codegen: CodeCodegen) {
 			//supportingFiles.clear()
 
 			val inputRoot = "app-module/src/main/resources/liquibase"
-			val destinationRoot = "app-${artifactId.toLowerCase()}/src/main/resources/liquibase"
+			val destinationRoot = "$modulePrefixName${artifactId.toLowerCase()}/src/main/resources/liquibase"
 
 			addSupportFile(source = "$inputRoot/liquibase-changeLog.xml", target = "$destinationRoot/liquibase-changeLog.xml")
 			addSupportFile(source = "$inputRoot/settings.xml.mustache", target = "$destinationRoot/settings.xml")
@@ -304,7 +307,7 @@ class OptsPostProcessor(val codegen: CodeCodegen) {
 
 	private fun setupModuleFiles() {
 		val inputRoot = "app-module/"
-		val destinationRoot = "app-${artifactId.toLowerCase()}"
+		val destinationRoot = "$modulePrefixName${artifactId.toLowerCase()}"
 		addSupportFile(source = "$inputRoot/build.gradle.kts.mustache",  target = "$destinationRoot/build.gradle.kts")
 		// add kubernetes manifests for the application
 		deployment.addAppFiles(artifactId)

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/filename/FilePathResolver.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/filename/FilePathResolver.kt
@@ -3,7 +3,7 @@ package pro.bilous.codegen.process.filename
 import org.slf4j.LoggerFactory
 import java.io.File
 import org.openapitools.codegen.CodeCodegen
-import pro.bilous.codegen.process.deployment.DeploymentFileResolver
+import org.openapitools.codegen.CodeCodegen.Companion.resolveModulePrefixName
 
 class FilePathResolver {
 
@@ -62,13 +62,15 @@ class FilePathResolver {
 
 	private fun resolveCommon(templateData: Map<String, Any>, templateName: String, filePath: String): String {
 		val separator = File.separator
+		val sourceFolder = "${separator}src${separator}"
+		val modulePrefixName = resolveModulePrefixName(templateData)
 		val appPackagePath = (templateData["appPackage"] as String).replace(".", separator)
 		val appName = templateData["appNameLower"] as String
 		val basePackagePath = (templateData["basePackage"] as String).replace(".", separator)
 		log.debug("found appName: $appName, appPackagePath: $appPackagePath, basePackagePath: $basePackagePath")
 		return filePath
 			// 1st replace app folder to common. example: app-user to common
-			.replace("app-$appName", "common")
+			.replace("$modulePrefixName$appName$sourceFolder", "common$sourceFolder")
 			// 2nd replace app package to the common package (base) example: /app/client/user/ to /app/client/
 			.replace("$separator$appPackagePath$separator", "$separator$basePackagePath$separator")
 	}

--- a/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/kotlin/domain/modulePrefixNameDefinition.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/kotlin/domain/modulePrefixNameDefinition.mustache
@@ -1,0 +1,1 @@
+{{#generation.modulePrefixName}}{{generation.modulePrefixName}}{{/generation.modulePrefixName}}{{^generation.modulePrefixName}}app-{{/generation.modulePrefixName}}

--- a/codegen-cli/src/main/resources/kotlin-codegen/docker-compose.yml.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/docker-compose.yml.mustache
@@ -14,8 +14,8 @@ services:
     volumes:
       - db_data:/var/lib/mysql
 {{#appsMap}}
-  app-{{name}}:
-    image: app-{{name}}:0.0.1
+  {{>app-module/src/main/kotlin/domain/modulePrefixNameDefinition}}{{name}}:
+    image: {{>app-module/src/main/kotlin/domain/modulePrefixNameDefinition}}{{name}}:0.0.1
     restart: on-failure
     environment:
       DB_HOST: db

--- a/codegen-cli/src/main/resources/kotlin-codegen/settings.gradle.kts.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/settings.gradle.kts.mustache
@@ -1,5 +1,5 @@
 rootProject.name = "{{systemLower}}-system"
 include("common")
 {{#appsLower}}
-include("app-{{.}}")
+include("{{>app-module/src/main/kotlin/domain/modulePrefixNameDefinition}}{{.}}")
 {{/appsLower}}


### PR DESCRIPTION
To specify the custom prefix (like 'new-prefix-') instead of the default 'app-' for the module the setting must be added to settings.yml:
**generation:
  modulePrefixName: new-prefix-**

If the prefix must be omitted the empty string must be specified:
**generation:
  modulePrefixName: ""**